### PR TITLE
Add options to customize font family

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,20 @@ pod 'CardIO'
 When using React Native versions < 0.60, the following must also be added to your `Podfile`:
 
 ```
-pod 'Braintree' 
+pod 'Braintree'
 
 pod 'BraintreeDropIn'
 
- # comment the next line to disable Apple pay 
+ # comment the next line to disable Apple pay
 pod 'Braintree/Apple-Pay'
 
- # comment the next line to disable PayPal  
-pod 'Braintree/PayPal'  
+ # comment the next line to disable PayPal
+pod 'Braintree/PayPal'
 
- # comment the next line to disable Venmo 
-pod 'Braintree/Venmo' 
+ # comment the next line to disable Venmo
+pod 'Braintree/Venmo'
 
- # Data collector for Braintree Advanced Fraud Tools  
+ # Data collector for Braintree Advanced Fraud Tools
 pod 'Braintree/DataCollector'
 ```
 
@@ -116,8 +116,8 @@ If you wish to support Google Pay, add in your `AndroidManifest.xml`:
 
 ```
     <!-- Enables the Google Pay API -->
-    <meta-data 
-        android:name="com.google.android.gms.wallet.api.enabled" 
+    <meta-data
+        android:name="com.google.android.gms.wallet.api.enabled"
         android:value="true"/>
 ```
 
@@ -209,7 +209,7 @@ func application(_ app: UIApplication, open url: URL, options: [UIApplication.Op
     }
     return RCTLinkingManager.application(app, open: url, options: options)
 }
-    
+
 private var paymentsURLScheme: String {
     let bundleIdentifier = Bundle.main.bundleIdentifier ?? ""
     return bundleIdentifier + ".payments"
@@ -284,6 +284,14 @@ BraintreeDropIn.show({
   }
 });
 ```
+
+### Custom Fonts
+
+BraintreeDropIn.show({
+  ...
+  fontFamily: 'Averta-Regular',
+  boldFontFamily: 'Averta-Semibold',
+})
 
 [1]:  http://guides.cocoapods.org/using/using-cocoapods.html
 [2]:  https://github.com/braintree/braintree-ios-drop-in

--- a/ios/RNBraintreeDropIn.m
+++ b/ios/RNBraintreeDropIn.m
@@ -13,15 +13,22 @@ RCT_EXPORT_MODULE(RNBraintreeDropIn)
 RCT_EXPORT_METHOD(show:(NSDictionary*)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
 
-if([options[@"darkTheme"] boolValue]){
-    if (@available(iOS 13.0, *)) {
-        BTUIKAppearance.sharedInstance.colorScheme = BTUIKColorSchemeDynamic;
+    if([options[@"darkTheme"] boolValue]){
+        if (@available(iOS 13.0, *)) {
+            BTUIKAppearance.sharedInstance.colorScheme = BTUIKColorSchemeDynamic;
+        } else {
+            BTUIKAppearance.sharedInstance.colorScheme = BTUIKColorSchemeDark;
+        }
     } else {
-        BTUIKAppearance.sharedInstance.colorScheme = BTUIKColorSchemeDark;
-    }
-} else {
         BTUIKAppearance.sharedInstance.colorScheme = BTUIKColorSchemeLight;
-}
+    }
+
+    if(options[@"fontFamily"]){
+        [BTUIKAppearance sharedInstance].fontFamily = options[@"fontFamily"];
+    }
+    if(options[@"boldFontFamily"]){
+        [BTUIKAppearance sharedInstance].boldFontFamily = options[@"boldFontFamily"];
+    }
 
     self.resolve = resolve;
     self.reject = reject;


### PR DESCRIPTION
Add two new options that can be passed to the `show()` command on the JS side, that allow for customizing the normal and bold font faces.

1. Without the options, the UI is shown as it does in the past:

<img width="333" alt="bt-1-no-font-option" src="https://user-images.githubusercontent.com/788325/76467489-05dba800-63ea-11ea-8b81-755ede413dd9.png">


2. Specify alternate fonts:

```
BraintreeDropIn.show({
  ...
  fontFamily: 'Averta-Regular',
  boldFontFamily: 'Averta-Semibold',
})
```

3. UI shown with those fonts:
<img width="320" alt="bt-4-font-option" src="https://user-images.githubusercontent.com/788325/76467493-070cd500-63ea-11ea-83f4-6176deb28330.png">
