### PR TITLE
Adding paypal control

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ BraintreeDropIn.show({
   googlePay: true,
   applePay: true,
   vaultManager: true,
+  paypal: true, 
   cardDisabled: false,
   darkTheme: true,
 })
@@ -284,6 +285,7 @@ BraintreeDropIn.show({
   googlePay: true,
   applePay: true,
   vaultManager: true,
+  paypal: true, 
   cardDisabled: false,
   darkTheme: true,
 })

--- a/android/src/main/java/tech/power/RNBraintreeDropIn/RNBraintreeDropInModule.java
+++ b/android/src/main/java/tech/power/RNBraintreeDropIn/RNBraintreeDropInModule.java
@@ -88,6 +88,10 @@ public class RNBraintreeDropInModule extends ReactContextBaseJavaModule {
       .amount(String.valueOf(threeDSecureOptions.getDouble("amount")))
       .requestThreeDSecureVerification(true);
     }
+    
+    if(!options.getBoolean("payPal")){ //disable paypal
+      dropInRequest.disablePayPal();
+    }
 
     mPromise = promise;
     currentActivity.startActivityForResult(dropInRequest.getIntent(currentActivity), DROP_IN_REQUEST);

--- a/ios/RNBraintreeDropIn.m
+++ b/ios/RNBraintreeDropIn.m
@@ -100,6 +100,10 @@ RCT_EXPORT_METHOD(show:(NSDictionary*)options resolver:(RCTPromiseResolveBlock)r
     }else{
         request.applePayDisabled = YES;
     }
+    
+    if(![options[@"payPal"] boolValue]){ //disable paypal
+        request.paypalDisabled = YES;
+    }
 
     BTDropInController *dropIn = [[BTDropInController alloc] initWithAuthorization:clientToken request:request handler:^(BTDropInController * _Nonnull controller, BTDropInResult * _Nullable result, NSError * _Nullable error) {
             [self.reactRoot dismissViewControllerAnimated:YES completion:nil];


### PR DESCRIPTION
Fixes issue [#60](https://github.com/wgltony/react-native-braintree-dropin-ui/issues/60)
## What problem are we trying to solve?
Upon integrating `react-native-braintree-dropin-ui` into an existing React Native project with a pre-existing module that handles `Paypal` payments, we needed a way to disable `Paypal` payment method via the Drop-in.
## Why should we solve it?
While we appreciate that other apps might not need or even require this particular option, its addition would allow developers to have full control over the payment methods they want to use. Currently this module offers the options to disable `googlePay`,`applePay` and `CreditCards` but does not have the same option for disabling `Paypal`.
## How do we propose to solve it?
We already have a patch file that adds this option to the react native layer and also adds supporting functionality to both native platforms.
A further change would be to update documentation to detail this change.
## What could go wrong?
This option would be disabled by default which would match current expected behaviour.
