### PR TITLE
Fix for `Problems reading data from Binary store` and fix for google play app rejection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-## This version contains updated BraintreeDropIn 5.+
-
-BraintreeDropIn 5.0.2 contains some security fixes that resolves Play store rejection fix. Read more - 
-
-Unsafe implementation of the HostnameVerifier interface - vulnerability ( https://github.com/braintree/braintree-android-drop-in/issues/208 )
-
-
 # react-native-braintree-dropin-ui
 
 > React Native integration of Braintree Drop-in for IOS & ANDROID (Apple Pay, Google Pay, Paypal, Venmo, Credit Card)
@@ -313,6 +306,13 @@ BraintreeDropIn.show({
   boldFontFamily: 'Averta-Semibold',
 })
 ```
+
+### Potential Fix 
+
+This version contains updated BraintreeDropIn 5.+. BraintreeDropIn 5.0.2 contains some security fixes that resolves Play store rejection fix. Read more - 
+
+Unsafe implementation of the HostnameVerifier interface - vulnerability ( https://github.com/braintree/braintree-android-drop-in/issues/208 )
+
 [1]:  http://guides.cocoapods.org/using/using-cocoapods.html
 [2]:  https://github.com/braintree/braintree-ios-drop-in
 [3]:  https://github.com/braintree/braintree-android-drop-in

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+## This version contains updated BraintreeDropIn 5.+
+
+BraintreeDropIn 5.0.2 contains some security fixes that resolves Play store rejection fix. Read more - 
+
+Unsafe implementation of the HostnameVerifier interface - vulnerability ( https://github.com/braintree/braintree-android-drop-in/issues/208 )
+
+
 # react-native-braintree-dropin-ui
 
 > React Native integration of Braintree Drop-in for IOS & ANDROID (Apple Pay, Google Pay, Paypal, Venmo, Credit Card)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'com.braintreepayments.api:google-payment:3.2.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.1'
     implementation 'com.braintreepayments.api:data-collector:2.+'
-    implementation 'com.braintreepayments.api:drop-in:4.+'
+    implementation 'com.braintreepayments.api:drop-in:5.+'
     implementation 'com.facebook.react:react-native:+'
 }
 
@@ -43,10 +43,10 @@ dependencies {
 rootProject.allprojects {
     repositories {
         maven {
-            url  "https://cardinalcommerce.bintray.com/android"
+            url "https://cardinalcommerceprod.jfrog.io/artifactory/android"
             credentials {
-                username 'braintree-team-sdk@cardinalcommerce'
-                password '220cc9476025679c4e5c843666c27d97cfb0f951'
+                username 'braintree_team_sdk'
+                password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
             }
         }
     }


### PR DESCRIPTION
- Fix for `Problems reading data from Binary store` by updating `Cardinal Mobile SDK` credentials
- Fix for google play app rejection updating to `com.braintreepayments.api:drop-in:5.+`