### PR TITLE
Fix paypal configuration attribute typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ BraintreeDropIn.show({
   googlePay: true,
   applePay: true,
   vaultManager: true,
-  paypal: true, 
+  payPal: true, 
   cardDisabled: false,
   darkTheme: true,
 })
@@ -285,7 +285,7 @@ BraintreeDropIn.show({
   googlePay: true,
   applePay: true,
   vaultManager: true,
-  paypal: true, 
+  payPal: true, 
   cardDisabled: false,
   darkTheme: true,
 })


### PR DESCRIPTION
A typo in this PR:
https://github.com/wgltony/react-native-braintree-dropin-ui/pull/62

The correct config attribute is 'payPal' and not 'paypal'

This PR updates the correct usage in the README file