### PR TITLE
Fix build for React Native 0.69+

### DIFF
--- a/RNBraintreeDropIn.podspec
+++ b/RNBraintreeDropIn.podspec
@@ -1,17 +1,17 @@
 Pod::Spec.new do |s|
   s.name         = "RNBraintreeDropIn"
-  s.version      = "1.0.0"
+  s.version      = "1.1.3"
   s.summary      = "RNBraintreeDropIn"
   s.description  = <<-DESC
                   RNBraintreeDropIn
                    DESC
   s.homepage     = "https://github.com/bamlab/react-native-braintree-payments-drop-in"
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "../LICENSE" }
+  # s.license      = { :type => "MIT", :file => "./LICENSE" }
   s.author             = { "author" => "lagrange.louis@gmail.com" }
   s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/BradyShober/react-native-braintree-dropin-ui.git", :tag => "master" }
-  s.source_files  = "*.{h,m}"
+  s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
   s.dependency    'React'
   s.dependency    'Braintree'

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   dependency: {
     platforms: {
-      ios: { podspecPath: path.join(__dirname, 'ios', 'RNBraintreeDropIn.podspec') },
+      ios: {},
       android: {
       	packageImportPath: 'import tech.power.RNBraintreeDropIn.RNBraintreeDropInPackage;',
         packageInstance: 'new RNBraintreeDropInPackage()',


### PR DESCRIPTION
Summary of issue and description of fix in [#91](https://github.com/wgltony/react-native-braintree-dropin-ui/issues/91#issuecomment-1232266647):

> When React Native [removed `link` and `unlink` from the CLI](https://github.com/react-native-community/cli/releases/tag/v8.0.0), they also changed two things:
> 
> 1. The `*.podspec` file now needs to be [in the root of the project](https://github.com/react-native-community/cli/commit/25eec7c695f09aea0ace7c0b591844fe8828ccc5#diff-30560cbb6b72f5d4b12a887cfdecd79911c3cff868ec8ef828585bcc2dd4ee79R29).
> 1. A `podspecPath` can no longer be defined in `react-native.config.js`