### PR TITLE
build: use React-Core pod instead of React

### DIFF
--- a/RNBraintreeDropIn.podspec
+++ b/RNBraintreeDropIn.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/BradyShober/react-native-braintree-dropin-ui.git", :tag => "master" }
   s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
-  s.dependency    'React'
+  s.dependency    'React-Core'
   s.dependency    'Braintree', '5.20.1'
   s.dependency    'BraintreeDropIn', '9.8.1'
   s.dependency    'Braintree/DataCollector', '5.20.1'


### PR DESCRIPTION
Having React as s.dependency in podspec results in errors like "duplicate interface definition for RCTModuleRegistry", React-Core avoids this. Tested.