### PR TITLE
build: update braintree on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:drop-in:6.11.0'
+    implementation 'com.braintreepayments.api:drop-in:6.13.0'
     implementation 'com.facebook.react:react-native:+'
 }
 


### PR DESCRIPTION
google play doesn't allow braintree-dropin 6.11 anymore, so it needs to be bumped