### PR TITLE
Repoint RNBraintreeDropIn.podspec to home repo

### DIFF
--- a/RNBraintreeDropIn.podspec
+++ b/RNBraintreeDropIn.podspec
@@ -5,12 +5,12 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNBraintreeDropIn
                    DESC
-  s.homepage     = "https://github.com/bamlab/react-native-braintree-payments-drop-in"
+  s.homepage     = "https://github.com/wgltony/react-native-braintree-payments-drop-in"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "./LICENSE" }
   s.author             = { "author" => "lagrange.louis@gmail.com" }
   s.platform     = :ios, "12.0"
-  s.source       = { :git => "https://github.com/BradyShober/react-native-braintree-dropin-ui.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/wgltony/react-native-braintree-dropin-ui.git", :tag => "master" }
   s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
   s.dependency    'React'


### PR DESCRIPTION
The pod spec points to different places.